### PR TITLE
Prevent crashing when globals are missing

### DIFF
--- a/lib/walker.js
+++ b/lib/walker.js
@@ -206,8 +206,11 @@ function populateGlobals(meta, scopeManager) {
     }
   }
 
-  envNames.forEach(e =>
-    Object.keys(globals[e]).forEach(g => globalNames.add(g)));
+  envNames.forEach(e => {
+    if (globals[e]) {
+      Object.keys(globals[e]).forEach(g => globalNames.add(g));
+    }
+  });
 
   // to identify imports and exports, we must have these globals
   ["require", "module", "exports"].forEach(g => globalNames.add(g));


### PR DESCRIPTION
My `envNames` looked like `[ 'builtin', 'browser', 'node', 'es6', 'jest/globals' ]` and tradehip was crashing because `globals` doesn't have anything for `jest/globals`.